### PR TITLE
feat: added support for data sections without name

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -469,7 +469,7 @@ module.exports = grammar({
     ),
 
     data_statement: $ => seq(
-      reservedWord("data"), $.data_name, optional($.data_commands_allowed), $.statement_block
+      reservedWord("data"), optional($.data_name), optional($.data_commands_allowed), $.statement_block
     ),
 
     data_name: $ =>$.simple_name,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3909,8 +3909,16 @@
           "value": "data"
         },
         {
-          "type": "SYMBOL",
-          "name": "data_name"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "data_name"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",


### PR DESCRIPTION
According to documentation name is optional for data sections:
https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_data_sections?view=powershell-7.4#using-a-data-section
