### PR TITLE
deps: bump tree-sitter to 0.25.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-powershell"
 description = "powershell grammar for the tree-sitter parsing library"
-version = "0.24.5"
+version = "0.25.2"
 keywords = ["incremental", "parsing", "powershell"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-powershell"
@@ -9,18 +9,13 @@ edition = "2018"
 license = "MIT"
 
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.24.4"
+tree-sitter = "0.25.2"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,10 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.25.2"
+tree-sitter-language = "0.1"
 
 [build-dependencies]
 cc = "1.0"
+
+[dev-dependencies]
+tree-sitter = "0.25.2"

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_powershell::language()).expect("Error loading powershell grammar");
+//! parser.set_language(&tree_sitter_powershell::LANGUAGE.into()).expect("Error loading powershell grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -15,18 +15,16 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_powershell() -> Language;
+    fn tree_sitter_powershell() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
+/// The tree-sitter [`LanguageFn`][LanguageFn] for this grammar.
 ///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_powershell() }
-}
+/// [LanguageFn]: https://docs.rs/tree-sitter-language/*/tree_sitter_language/struct.LanguageFn.html
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_powershell) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
@@ -46,7 +44,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::LANGUAGE.into())
             .expect("Error loading powershell language");
     }
 }


### PR DESCRIPTION
This brings this crate up to the latest `tree-sitter` release. It also turns `tree-sitter` into a dev-dependency and replaces it at runtime with `tree-sitter-language`, which provides the same APIs needed without an implicit ABI dependency on a particular release of `tree-sitter`.

Together, these changes should (1) make this crate compatible with the latest tree-sitter, and (2) make it much more compatible going forwards, since changes to tree-sitter won't require bumps here.

CC @citronneur 

