### PR TITLE
Fix minor variable grammar bugs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -209,14 +209,14 @@ module.exports = grammar({
       // Simple variable with $ or spalted with @
       token(seq(
         choice('$', '@'), 
-        optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("function"), /[a-zA-Z0-9_]+/), ":")), 
+        optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("alias"), reservedWord("env"), reservedWord("function"), reservedWord("variable"), /[a-zA-Z0-9_]+/), ":")), 
         /([a-zA-Z0-9_?]+:?)+/
       )),
       
       // Braced variable surrounded by ${}
       token(seq(
         "${", 
-        optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("function"), /[a-zA-Z0-9_]+/), ":")), 
+        optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("alias"), reservedWord("env"), reservedWord("function"), reservedWord("variable"), /[a-zA-Z0-9_]+/), ":")), 
         /([^}]|`\})+\}/
       )),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -217,13 +217,18 @@ module.exports = grammar({
       /[a-zA-Z0-9_]+|\?/
     )),
     
-    variable: $ => choice(
+    variable: _ => choice(
       '$$',
       '$^',
       '$?',
       '$_',
-      seq(choice('$', '@'), $.variable_name),
-      seq('${', $.variable_name, '}'),
+      '$::',  // Weird variable allowed in powershell
+      
+      // Simple variable with $ or spalted with @
+      token(seq(choice('$', '@'), optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("function"), /[a-zA-Z0-9_]+/), ":")), /([a-zA-Z0-9_?]+:?)+/)),
+      
+      // Braced variable surrounded by ${}
+      token(seq("${", optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("function"), /[a-zA-Z0-9_]+/), ":")), /([^}]|`\})+\}/)),
     ),
 
     // Commands

--- a/grammar.js
+++ b/grammar.js
@@ -199,24 +199,6 @@ module.exports = grammar({
     format_operator: $ => reservedWord("-f"),
 
     // Variables
-    variable_name: _ => token(seq(
-      optional(
-        seq(
-          choice(
-            reservedWord("global:"), 
-            reservedWord("local:"), 
-            reservedWord("private:"), 
-            reservedWord("script:"), 
-            reservedWord("using:"), 
-            reservedWord("workflow:"), 
-            /[a-zA-Z0-9_]+/
-          ), 
-          ":"
-        )
-      ), 
-      /[a-zA-Z0-9_]+|\?/
-    )),
-    
     variable: _ => choice(
       '$$',
       '$^',
@@ -225,10 +207,18 @@ module.exports = grammar({
       '$::',  // Weird variable allowed in powershell
       
       // Simple variable with $ or spalted with @
-      token(seq(choice('$', '@'), optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("function"), /[a-zA-Z0-9_]+/), ":")), /([a-zA-Z0-9_?]+:?)+/)),
+      token(seq(
+        choice('$', '@'), 
+        optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("function"), /[a-zA-Z0-9_]+/), ":")), 
+        /([a-zA-Z0-9_?]+:?)+/
+      )),
       
       // Braced variable surrounded by ${}
-      token(seq("${", optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("function"), /[a-zA-Z0-9_]+/), ":")), /([^}]|`\})+\}/)),
+      token(seq(
+        "${", 
+        optional(seq(choice(reservedWord("global"), reservedWord("local"), reservedWord("private"), reservedWord("script"), reservedWord("using"), reservedWord("workflow"), reservedWord("function"), /[a-zA-Z0-9_]+/), ":")), 
+        /([^}]|`\})+\}/
+      )),
     ),
 
     // Commands

--- a/grammar.js
+++ b/grammar.js
@@ -199,17 +199,32 @@ module.exports = grammar({
     format_operator: $ => reservedWord("-f"),
 
     // Variables
+    variable_name: _ => token(seq(
+      optional(
+        seq(
+          choice(
+            reservedWord("global:"), 
+            reservedWord("local:"), 
+            reservedWord("private:"), 
+            reservedWord("script:"), 
+            reservedWord("using:"), 
+            reservedWord("workflow:"), 
+            /[a-zA-Z0-9_]+/
+          ), 
+          ":"
+        )
+      ), 
+      /[a-zA-Z0-9_]+|\?/
+    )),
+    
     variable: $ => choice(
       '$$',
       '$^',
       '$?',
       '$_',
-      token(seq('$', optional(seq(choice(reservedWord("global:"), reservedWord("local:"), reservedWord("private:"), reservedWord("script:"), reservedWord("using:"), reservedWord("workflow:"), /[a-zA-Z0-9_]+/), ":")), /[a-zA-Z0-9_]+|\?/)),
-      token(seq('@', optional(seq(choice(reservedWord("global:"), reservedWord("local:"), reservedWord("private:"), reservedWord("script:"), reservedWord("using:"), reservedWord("workflow:"), /[a-zA-Z0-9_]+/), ":")), /[a-zA-Z0-9_]+|\?/)),
-      $.braced_variable
+      seq(choice('$', '@'), $.variable_name),
+      seq('${', $.variable_name, '}'),
     ),
-
-    braced_variable: $=> /\$\{[^}]+\}/,
 
     // Commands
     generic_token: $ => token(


### PR DESCRIPTION
Create a new token to match the variable names only, without the `$`, `@` or `${...}`