### PR TITLE
Fix peerDependenciesMeta key for tree-sitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tree-sitter": "^0.25.0"
   },
   "peerDependenciesMeta": {
-    "tree_sitter": {
+    "tree-sitter": {
       "optional": true
     }
   },


### PR DESCRIPTION
Due to a typo in `package.json`, the `tree-sitter` peer dependency is treated as non-optional.