### PR TITLE
Fix link to Git repository in tree-sitter.json

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -20,7 +20,7 @@
     "license": "MIT",
     "description": "",
     "links": {
-      "repository": "https://github.com/tree-sitter/tree-sitter-powershell"
+      "repository": "https://github.com/airbus-cert/tree-sitter-powershell"
     }
   },
   "bindings": {


### PR DESCRIPTION
It could be worth re-generating the bindings (with `tree-sitter init -u`) after that (perhaps even delete the bindings before).