### PR TITLE
Rust bindings: fix doctest and include highlight queries

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -5,6 +5,7 @@
 //!
 //! ```
 //! let code = r#"
+//! 123
 //! "#;
 //! let mut parser = tree_sitter::Parser::new();
 //! let language = tree_sitter_powershell::LANGUAGE;
@@ -34,7 +35,7 @@ pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");


### PR DESCRIPTION
Thanks for regenerating the bindings!
This small manual edit is to make sure that `cargo test` passes. Also lets Rust reusers access the highlight queries.
Of course it will be overridden at the next bindings re-generation… :-(
For the second part at least, manual edits soon shouldn't be necessary anymore: https://github.com/tree-sitter/tree-sitter/pull/4955