### PR TITLE
Add query-based folding for region and signature comments

### DIFF
--- a/queries/folds.scm
+++ b/queries/folds.scm
@@ -1,0 +1,15 @@
+; Multiline block comments
+((comment) @fold
+  (#match? @fold "^<#"))
+
+; PowerShell editor region markers
+((comment) @fold.start
+  (#match? @fold.start "^#region\\b"))
+((comment) @fold.end
+  (#match? @fold.end "^#endregion\\b"))
+
+; Script signature block markers
+((comment) @fold.start
+  (#match? @fold.start "^#\\s*SIG\\s+#\\s*Begin\\s+signature\\s+block\\b"))
+((comment) @fold.end
+  (#match? @fold.end "^#\\s*SIG\\s+#\\s*End\\s+signature\\s+block\\b"))

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -183,6 +183,72 @@ $a
                           (variable))))))))))))))
 
 ===
+Special comment: #Requires
+===
+
+#Requires -Version 7.0
+Get-ChildItem .
+
+---
+
+(program
+  (comment)
+  (statement_list
+    (pipeline
+      (pipeline_chain
+        (command
+          (command_name)
+          (command_elements
+            (command_argument_sep)
+            (generic_token)))))))
+
+===
+Special comments: #region pair
+===
+
+#region Utilities
+Get-ChildItem .
+#endregion
+
+---
+
+(program
+  (comment)
+  (statement_list
+    (pipeline
+      (pipeline_chain
+        (command
+          (command_name)
+          (command_elements
+            (command_argument_sep)
+            (generic_token))))))
+  (comment))
+
+===
+Special comments: # SIG block
+===
+
+# SIG # Begin signature block
+# MIIFakeSignatureLine
+# SIG # End signature block
+Get-ChildItem .
+
+---
+
+(program
+  (comment)
+  (comment)
+  (comment)
+  (statement_list
+    (pipeline
+      (pipeline_chain
+        (command
+          (command_name)
+          (command_elements
+            (command_argument_sep)
+            (generic_token)))))))
+
+===
 Pathological block comment #2
 ===
 

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -203,6 +203,26 @@ Get-ChildItem .
             (generic_token)))))))
 
 ===
+Special comment: shebang
+===
+
+#!/usr/bin/env pwsh
+Get-ChildItem .
+
+---
+
+(program
+  (comment)
+  (statement_list
+    (pipeline
+      (pipeline_chain
+        (command
+          (command_name)
+          (command_elements
+            (command_argument_sep)
+            (generic_token)))))))
+
+===
 Special comments: #region pair
 ===
 
@@ -223,6 +243,47 @@ Get-ChildItem .
             (command_argument_sep)
             (generic_token))))))
   (comment))
+
+===
+Comment-based help: block comment
+===
+
+<#
+.SYNOPSIS
+Test block help comment.
+.DESCRIPTION
+More details.
+#>
+function while {}
+
+---
+
+(program
+  (comment)
+  (statement_list
+    (function_statement
+      (function_name))))
+
+===
+Comment-based help: line comments
+===
+
+# .SYNOPSIS
+# Test line help comment.
+# .DESCRIPTION
+# More details.
+function while {}
+
+---
+
+(program
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (statement_list
+    (function_statement
+      (function_name))))
 
 ===
 Special comments: # SIG block

--- a/test/corpus/strings.txt
+++ b/test/corpus/strings.txt
@@ -333,6 +333,54 @@ Strings : concat var content and dollar
                               (variable))))))))))))))))
 
 ===
+Strings : Regex inline comment stays string
+===
+
+"(?# this is a regex inline comment)oo"
+
+---
+
+(program
+  (statement_list
+    (pipeline
+      (pipeline_chain
+        (logical_expression
+          (bitwise_expression
+            (comparison_expression
+              (additive_expression
+                (multiplicative_expression
+                  (format_expression
+                    (range_expression
+                      (array_literal_expression
+                        (unary_expression
+                          (string_literal
+                            (expandable_string_literal)))))))))))))))
+
+===
+Strings : Regex # comment stays string
+===
+
+"(?x)oo# regex comment in expanded mode"
+
+---
+
+(program
+  (statement_list
+    (pipeline
+      (pipeline_chain
+        (logical_expression
+          (bitwise_expression
+            (comparison_expression
+              (additive_expression
+                (multiplicative_expression
+                  (format_expression
+                    (range_expression
+                      (array_literal_expression
+                        (unary_expression
+                          (string_literal
+                            (expandable_string_literal)))))))))))))))
+
+===
 Strings : Single-quoted string
 ===
 

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -8,6 +8,7 @@
       "path": ".",
       "file-types": ["ps1", "psm1"],
       "highlights": ["queries/highlights.scm"],
+      "folds": ["queries/folds.scm"],
       "injection-regex": "^(ps1|psm1)$"
     }
   ],


### PR DESCRIPTION
PowerShell treats `#region/#endregion`, `# SIG` signature markers, and `#Requires` as comments, but we still want reliable editor folding and explicit parser coverage for those special forms.

This PR keeps comment parsing unchanged and adds query-based folding metadata instead of splitting grammar nodes.

## What changed
- add `queries/folds.scm` with folding captures for:
  - multiline block comments (`<# ... #>`)
  - `#region` / `#endregion`
  - `# SIG # Begin signature block` / `# SIG # End signature block`
- wire fold queries in `tree-sitter.json` via `"folds": ["queries/folds.scm"]`
- extend corpus tests in `test/corpus/comments.txt` for:
  - `#Requires`
  - shebang comment (`#!/usr/bin/env pwsh`)
  - region marker pair
  - signature block markers
  - comment-based help (`.SYNOPSIS`, `.DESCRIPTION`) in block and line-comment forms
- extend corpus tests in `test/corpus/strings.txt` to confirm regex comment syntax inside strings (`(?#...)`, `(?x)...#...`) remains string content

## Notes for reviewers
- special PowerShell comment forms intentionally remain `comment` tokens; behavior-specific handling is done in queries and tests
- this is tuned for generic tree-sitter fold-query consumers